### PR TITLE
fix: Include '.exe' suffix on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
     "tmp": "^0.1.0",
     "universal-analytics": "^0.4.23",
     "vscode-debugadapter": "1.38.0",
-    "wait-port": "^0.2.7"
+    "wait-port": "^0.2.7",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@entan.gl/vsce": "^1.79.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,7 @@ specifiers:
   webpack: ^5.11.1
   webpack-cli: ^4.3.0
   webpack-dev-server: ^3.11.1
+  which: ^2.0.2
 
 dependencies:
   '@entan.gl/vice-rainbow-monitor': 1.0.6
@@ -82,6 +83,7 @@ dependencies:
   universal-analytics: 0.4.23
   vscode-debugadapter: 1.38.0
   wait-port: 0.2.9
+  which: 2.0.2
 
 devDependencies:
   '@entan.gl/vsce': 1.79.6
@@ -3547,7 +3549,6 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
-    dev: true
 
   /isobject/2.1.0:
     resolution: {integrity: sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=}
@@ -6845,7 +6846,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}

--- a/src/dbg/runtime.ts
+++ b/src/dbg/runtime.ts
@@ -1313,7 +1313,8 @@ or define the location manually with the launch.json->mapFile setting`
             //
             // Here we fall back on the imported 'hasbin()' module to repeat the $PATH search.
             // This works on Linux and Windows, but does not handle the case where 'exePath' is
-            // the full path to the desired binary.
+            // the full path to the desired binary.  (Hence the prior 'fs.access()' and 'which()'
+            // checks).
             return new Promise((accept, reject) => {
                 hasbin.first([exePath],
                     (result) => result

--- a/src/dbg/runtime.ts
+++ b/src/dbg/runtime.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
-import * as hotel from 'hasbin';
+import * as hasbin from 'hasbin';
+import * as which from 'which';
 import * as typeQuery from '../lib/type-query';
 import _first from 'lodash/fp/first';
 import _flow from 'lodash/fp/flow';
@@ -1268,6 +1269,59 @@ or define the location manually with the launch.json->mapFile setting`
     private _getCurrentScope() : debugFile.Scope | undefined {
         return this._getScope(this._currentPosition);
     }
+    
+    private static async _which(exePath: string): Promise<string> {
+        // Helper resolves to 'true' if the given file path can be read from this process.
+        const canAccess = (file) => new Promise((accept) => {
+            fs.access(file, fs.constants.R_OK, (err) => {
+                accept(!err);
+            });
+        });
+    
+        exePath = path.normalize(exePath);
+    
+        // When probing for an executable we need to consider three special cases:
+        //
+        //   1.  If the given 'exePath' contains only a file name (as opposed to a full path)
+        //       then we should search for the binary at the paths specified in 'process.env.PATH'.
+        //
+        //   2.  On Windows, we need to include the various executable extensions (.exe, .com, etc.)
+        //       as specified by 'process.env.PATHEXT'.
+        //
+        //   3.  On Linux, 'Mesen.exe' is a Mono application and therefore does not have executable
+        //       permissions (i.e., it lacks '+x').
+        //
+        // The imported 'which()' module handles cases 1 & 2, but rejects 'Mesen.exe' on Linux.
+        // Therefore we use a combination of 'fs.access()', 'which()', and 'hasbin()' as noted below.
+        
+        // First we uses a simple 'fs.access()' check, which does not search the $PATH or handle
+        // the Windows executable extensions (.exe, .com, etc.), but does handle the case where
+        // 'exePath' is a full path to 'Mesen.exe'.
+        if (await canAccess(exePath)) {
+            return exePath;
+        }
+    
+        try {
+            // If the 'fs.access()' check above did not find the binary we then invoke 'which()'.
+            // This handles both executable extensions (.exe, .com, etc.) on Windows and will
+            // search $PATH when given only a file name.
+            return await which(exePath);
+        } catch (whichErr) {
+            // The last case we need to consider is when 'mesenDirectory' was not configured.
+            // In this case, 'which()' may reject 'Mesen.exe' while searching the $PATH because
+            // 'Mesen.exe' lacks executable permissions on Linux.
+            //
+            // Here we fall back on the imported 'hasbin()' module to repeat the $PATH search.
+            // This works on Linux and Windows, but does not handle the case where 'exePath' is
+            // the full path to the desired binary.
+            return new Promise((accept, reject) => {
+                hasbin.first([exePath],
+                    (result) => result
+                        ? accept(result)        // On success return the name found in path (e.g., 'xpet.exe')
+                        : reject(whichErr));    // On failure preserve the error message from 'which()'
+            });
+        }
+    }
 
     // FIXME Push down into grip?
     private async _getEmulatorPath(viceDirectory: string | undefined, mesenDirectory: string | undefined, preferX64OverX64sc: boolean) : Promise<string> {
@@ -1278,7 +1332,7 @@ or define the location manually with the launch.json->mapFile setting`
             emulatorBaseName = 'Mesen.exe';
 
             if(mesenDirectory) {
-                emulatorPath = path.normalize(path.join(mesenDirectory, emulatorBaseName));
+                emulatorPath = path.join(mesenDirectory, emulatorBaseName);
             }
             else {
                 emulatorPath = emulatorBaseName;
@@ -1305,7 +1359,7 @@ or define the location manually with the launch.json->mapFile setting`
             }
 
             if(viceDirectory) {
-                emulatorPath = path.normalize(path.join(viceDirectory, emulatorBaseName));
+                emulatorPath = path.join(viceDirectory, emulatorBaseName);
             }
             else {
                 emulatorPath = emulatorBaseName;
@@ -1313,14 +1367,7 @@ or define the location manually with the launch.json->mapFile setting`
         }
 
         try {
-            try {
-                await util.promisify(fs.access)(emulatorPath)
-            }
-            catch {
-                await util.promisify((i, cb) =>
-                    hotel.first(i, (result) => result ? cb(null, result) : cb(new Error('Missing'), null))
-                )([emulatorPath])
-            }
+            emulatorPath = await Runtime._which(emulatorPath);
         }
         catch (e) {
             throw new Error(`Couldn't find the emulator. Make sure your \`cc65vice.viceDirectory\` or \`cc65vice.mesenDirectory\` user setting is pointing to the directory containing emulator executables. ${emulatorPath} ${e}`);


### PR DESCRIPTION
Here's a first proposal for fixing #90 that uses the popular 'which' package to probe for the binary.

'which' handles both a binary at a specific path (e.g., when "viceDirectory" is set) as well as returning the first match from the user's path when just a binary name is given.

In both cases, 'which' will automatically match files with executable suffixes like ".exe" (based on 'env.PATHEXT').

(Using the Dockerfile environment, the same small handful of tests fail before/after this change.)