### PR TITLE
fix: TypeError when launching emulators on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "@types/vscode": "1.49",
     "@types/webpack": "^4.41.25",
     "@types/webpack-dev-server": "^3.11.1",
+    "@types/which": "^2.0.1",
     "dotenv": "^8.2.0",
     "env-cmd": "^10.1.0",
     "glob": "^7.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   '@types/vscode': '1.49'
   '@types/webpack': ^4.41.25
   '@types/webpack-dev-server': ^3.11.1
+  '@types/which': ^2.0.1
   await-notify: 1.0.1
   buffer: ^6.0.3
   classnames: ^2.2.6
@@ -98,6 +99,7 @@ devDependencies:
   '@types/vscode': 1.49.0
   '@types/webpack': 4.41.25
   '@types/webpack-dev-server': 3.11.1
+  '@types/which': 2.0.1
   dotenv: 8.2.0
   env-cmd: 10.1.0
   glob: 7.1.6
@@ -1011,6 +1013,10 @@ packages:
       '@types/uglify-js': 3.11.1
       '@types/webpack-sources': 2.1.0
       source-map: 0.6.1
+    dev: true
+
+  /@types/which/2.0.1:
+    resolution: {integrity: sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==}
     dev: true
 
   /@types/yargs-parser/20.2.0:

--- a/src/dbg/runtime.ts
+++ b/src/dbg/runtime.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as hasbin from 'hasbin';
-import * as which from 'which';
+import which from 'which';
 import * as typeQuery from '../lib/type-query';
 import _first from 'lodash/fp/first';
 import _flow from 'lodash/fp/flow';


### PR DESCRIPTION
'which' must be imported as a legacy pre-ES6 module (Fixes #95)

(Note that this change may depend on PR #96.)