### PR TITLE
fix: do not kill -1 (all processes) on disconnect

### DIFF
--- a/src/dbg/debug-session.ts
+++ b/src/dbg/debug-session.ts
@@ -136,7 +136,7 @@ export class CC65ViceDebugSession extends LoggingDebugSession {
                 cleanup(() => {
                     for(const pid of pids) {
                         try {
-                            process.kill(pid);
+                            pid != -1 && process.kill(pid);
                         }
                         catch {}
                     }


### PR DESCRIPTION
This was an amusing bug. :-)

* On macOS, disconnecting the debugger caused all apps to terminate, the UI to disappear, and the desktop environment to restart.
* In a Linux container, disconnecting the debugger caused the init process (PID 1) to terminate, causing the container to shutdown.

**Root cause:**

On Unix-based systems, sending a signal to PID -1 targets all processes the user can signal.

**Solution:**

I noticed that elsewhere in the codebase you check for pid != -1. Adding the same check to the cleanup handler in 'debug-session.ts' resolves the issue.

**Verification:**

* Built locally
* Spliced output into '558.js' in a Linux dev container
* Confirmed that the init process (PID 1) now survives debugger disconnection, keeping the container alive

PS - This continues to be an amazing project!